### PR TITLE
counters example: update snabbdom version

### DIFF
--- a/examples/counters/1/main.js
+++ b/examples/counters/1/main.js
@@ -4,12 +4,12 @@ const Type = require('union-type');
 const flyd = require('flyd');
 const stream = flyd.stream;
 const patch = require('snabbdom').init([
-  require('snabbdom/modules/class'),
-  require('snabbdom/modules/props'),
-  require('snabbdom/modules/eventlisteners'),
-  require('snabbdom/modules/style'),
+  require('snabbdom/modules/class').default,
+  require('snabbdom/modules/props').default,
+  require('snabbdom/modules/eventlisteners').default,
+  require('snabbdom/modules/style').default,
 ]);
-const h = require('snabbdom/h');
+const h = require('snabbdom/h').default;
 
 
 // Update

--- a/examples/counters/2/counter.js
+++ b/examples/counters/2/counter.js
@@ -1,7 +1,7 @@
 /* jshint esnext: true */
 const R = require('ramda');
 const Type = require('union-type');
-const h = require('snabbdom/h');
+const h = require('snabbdom/h').default;
 
 
 // Model

--- a/examples/counters/2/main.js
+++ b/examples/counters/2/main.js
@@ -5,12 +5,12 @@ const stream = flyd.stream;
 const forwardTo = require('flyd-forwardto');
 const Type = require('union-type');
 const patch = require('snabbdom').init([
-  require('snabbdom/modules/class'),
-  require('snabbdom/modules/props'),
-  require('snabbdom/modules/eventlisteners'),
-  require('snabbdom/modules/style'),
+  require('snabbdom/modules/class').default,
+  require('snabbdom/modules/props').default,
+  require('snabbdom/modules/eventlisteners').default,
+  require('snabbdom/modules/style').default,
 ]);
-const h = require('snabbdom/h');
+const h = require('snabbdom/h').default;
 
 
 const counter = require('./counter.js');
@@ -37,7 +37,7 @@ const update = (model, action) =>
   }, action);
 
 // View
-const view = R.curry((actions$, model) => 
+const view = R.curry((actions$, model) =>
   h('div', [
     counter.view(forwardTo(actions$, Action.Top), model.topCounter),
     counter.view(forwardTo(actions$, Action.Bottom), model.bottomCounter),

--- a/examples/counters/3/counter.js
+++ b/examples/counters/3/counter.js
@@ -1,7 +1,7 @@
 /* jshint esnext: true */
 const R = require('ramda');
 const Type = require('union-type');
-const h = require('snabbdom/h');
+const h = require('snabbdom/h').default;
 
 
 // Model

--- a/examples/counters/3/main.js
+++ b/examples/counters/3/main.js
@@ -5,12 +5,12 @@ const stream = flyd.stream;
 const forwardTo = require('flyd-forwardto');
 const Type = require('union-type');
 const patch = require('snabbdom').init([
-  require('snabbdom/modules/class'),
-  require('snabbdom/modules/props'),
-  require('snabbdom/modules/eventlisteners'),
-  require('snabbdom/modules/style'),
+  require('snabbdom/modules/class').default,
+  require('snabbdom/modules/props').default,
+  require('snabbdom/modules/eventlisteners').default,
+  require('snabbdom/modules/style').default,
 ]);
-const h = require('snabbdom/h');
+const h = require('snabbdom/h').default;
 
 const counter = require('./counter.js');
 

--- a/examples/counters/4/counter.js
+++ b/examples/counters/4/counter.js
@@ -1,7 +1,7 @@
 /* jshint esnext: true */
 const R = require('ramda');
 const Type = require('union-type');
-const h = require('snabbdom/h');
+const h = require('snabbdom/h').default;
 
 
 // Model

--- a/examples/counters/4/main.js
+++ b/examples/counters/4/main.js
@@ -5,12 +5,12 @@ const stream = flyd.stream;
 const forwardTo = require('flyd-forwardto');
 const Type = require('union-type');
 const patch = require('snabbdom').init([
-  require('snabbdom/modules/class'),
-  require('snabbdom/modules/props'),
-  require('snabbdom/modules/eventlisteners'),
-  require('snabbdom/modules/style'),
+  require('snabbdom/modules/class').default,
+  require('snabbdom/modules/props').default,
+  require('snabbdom/modules/eventlisteners').default,
+  require('snabbdom/modules/style').default,
 ]);
-const h = require('snabbdom/h');
+const h = require('snabbdom/h').default;
 
 const counter = require('./counter.js');
 

--- a/examples/counters/package.json
+++ b/examples/counters/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "flyd-forwardto": "^0.0.1",
     "ramda": "^0.14.0",
-    "snabbdom": "^0.1.0",
+    "snabbdom": "^0.7.0",
     "flyd": "^0.1.4",
     "union-type": "^0.1.0"
   }


### PR DESCRIPTION
With the old version of snabbdom, I get an error on example 4 by:
1. Clicking 'add'
2. Clicking 'X' on the counter that appeared after step one. 

The error is `Uncaught TypeError: Cannot read property 'style' of undefined` and seems related to the ' ' elements in the child arrays in the viewWithRemoveButton function. Updating to a newer version resolved the problem for me.